### PR TITLE
Doc deprecation removal

### DIFF
--- a/docs/api-guide/generic-views.md
+++ b/docs/api-guide/generic-views.md
@@ -26,7 +26,6 @@ Typically when using the generic views, you'll override the view, and set severa
         queryset = User.objects.all()
         serializer_class = UserSerializer
         permission_classes = (IsAdminUser,)
-        paginate_by = 100
 
 For more complex cases you might also want to override various methods on the view class.  For example.
 

--- a/docs/api-guide/generic-views.md
+++ b/docs/api-guide/generic-views.md
@@ -71,8 +71,6 @@ The following attributes are used to control pagination when used with list view
 
 * `pagination_class` - The pagination class that should be used when paginating list results. Defaults to the same value as the `DEFAULT_PAGINATION_CLASS` setting, which is `'rest_framework.pagination.PageNumberPagination'`.
 
-Note that usage of the `paginate_by`, `paginate_by_param` and `page_kwarg` attributes are now pending deprecation. The `pagination_serializer_class` attribute and `DEFAULT_PAGINATION_SERIALIZER_CLASS` setting have been removed completely. Pagination settings should instead be controlled by overriding a pagination class and setting any configuration attributes there. See the pagination documentation for more details.
-
 **Filtering**:
 
 * `filter_backends` - A list of filter backend classes that should be used for filtering the queryset.  Defaults to the same value as the `DEFAULT_FILTER_BACKENDS` setting.

--- a/docs/api-guide/settings.md
+++ b/docs/api-guide/settings.md
@@ -119,15 +119,9 @@ If set to `None` then generic filtering is disabled.
 
 #### PAGINATE_BY
 
-The default page size to use for pagination.  If set to `None`, pagination is disabled by default.
-
-Default: `None`
-
-#### PAGINATE_BY_PARAM
-
 ---
 
-**This setting is pending deprecation.**
+**This setting has been removed.**
 
 See the pagination documentation for further guidance on [setting the pagination style](pagination.md#modifying-the-pagination-style).
 

--- a/docs/api-guide/settings.md
+++ b/docs/api-guide/settings.md
@@ -133,6 +133,16 @@ The default page size to use for pagination.  If set to `None`, pagination is di
 
 Default: `None`
 
+#### PAGINATE_BY_PARAM
+
+---
+
+**This setting has been removed.**
+
+See the pagination documentation for further guidance on [setting the pagination style](pagination.md#modifying-the-pagination-style).
+
+---
+
 #### MAX_PAGINATE_BY
 
 ---
@@ -142,22 +152,6 @@ Default: `None`
 See the pagination documentation for further guidance on [setting the pagination style](pagination.md#modifying-the-pagination-style).
 
 ---
-
-The maximum page size to allow when the page size is specified by the client.  If set to `None`, then no maximum limit is applied.
-
-For example, given the following settings:
-
-    REST_FRAMEWORK = {
-    	'PAGINATE_BY': 10,
-    	'PAGINATE_BY_PARAM': 'page_size',
-        'MAX_PAGINATE_BY': 100
-    }
-
-A client request like the following would return a paginated list of up to 100 items.
-
-    GET http://example.com/api/accounts?page_size=999
-
-Default: `None`
 
 ### SEARCH_PARAM
 

--- a/docs/api-guide/settings.md
+++ b/docs/api-guide/settings.md
@@ -102,9 +102,15 @@ Default: `'rest_framework.negotiation.DefaultContentNegotiation'`
 
 #### DEFAULT_PAGINATION_SERIALIZER_CLASS
 
-A class the determines the default serialization style for paginated responses.
+---
 
-Default: `rest_framework.pagination.PaginationSerializer`
+**This setting has been removed.**
+
+The pagination API does not use serializers to determine the output format, and
+you'll need to instead override the `get_paginated_response method on a
+pagination class in order to specify how the output format is controlled.
+
+---
 
 #### DEFAULT_FILTER_BACKENDS
 

--- a/docs/api-guide/settings.md
+++ b/docs/api-guide/settings.md
@@ -127,18 +127,9 @@ See the pagination documentation for further guidance on [setting the pagination
 
 ---
 
-The name of a query parameter, which can be used by the client to override the default page size to use for pagination.  If set to `None`, clients may not override the default page size.
+#### PAGE_SIZE
 
-For example, given the following settings:
-
-    REST_FRAMEWORK = {
-    	'PAGINATE_BY': 10,
-    	'PAGINATE_BY_PARAM': 'page_size',
-    }
-
-A client would be able to modify the pagination size by using the `page_size` query parameter.  For example:
-
-    GET http://example.com/api/accounts?page_size=25
+The default page size to use for pagination.  If set to `None`, pagination is disabled by default.
 
 Default: `None`
 


### PR DESCRIPTION
Some old settings / options were removed from the code but left in the documentation.
